### PR TITLE
feat: add legality check for movement

### DIFF
--- a/oo/src/board.ts
+++ b/oo/src/board.ts
@@ -91,6 +91,8 @@ export class Board<T> {
       return;
     }
 
+    if (!this.isLegalMove(first, second)) return;
+
     this.swap(first, second);
     this.print();
 
@@ -290,5 +292,27 @@ export class Board<T> {
 
   private printDimensionalArray<T>(arr: T[][]) {
     console.table(arr);
+  }
+
+  /**
+   * Checks if the intended move is a legal one. A move is legal if the two
+   * tiles are in the same row or the same column and the swap result in a
+   * match.
+   *
+   * @param selectedPosition - The selected position of the tile
+   * @param dropPosition - The drop position of the tile
+   *
+   * @returns Either the move is legal or not
+   */
+  private isLegalMove(selectedPosition: Position, dropPosition): boolean {
+    this.swap(selectedPosition, dropPosition);
+
+    // Check if the swap caused matches
+    const hasMatches = !!this.getMatches().length;
+
+    // Restore positions to initial state
+    this.swap(dropPosition, selectedPosition);
+
+    return hasMatches;
   }
 }


### PR DESCRIPTION
This commit adds a legality check for tile swaps, to ensure that only legal moves are allowed. A move is considered legal if the two tiles being swapped are in the same row or the same column, and the swap results in a match.

This commit also passes the "Board › moves › making moves › doesn't swap on illegal moves" test.